### PR TITLE
Make PhotonVision sim more realistic

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -36,6 +36,10 @@ public final class Constants {
         REPLAY
     }
 
+    public static final class FeatureFlags {
+        public static final boolean simulateVision = false;
+    }
+
     public static final class ConversionConstants {
         public static final double kRadiansPerSecondToRPM = 60.0 / (2.0 * Math.PI);
     }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -7,9 +7,13 @@ import com.ctre.phoenix6.mechanisms.swerve.SwerveModuleConstantsFactory;
 import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.geometry.Translation3d;
+import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
@@ -47,6 +51,9 @@ public final class Constants {
         public static final double MaxAngularRateRadiansPerSec = Math.PI * 2; // 2 PI is one full
         // rotation per second
         public static final double deadbandPercent = 0.16;
+
+        public static final Pose2d initialPose =
+                new Pose2d(new Translation2d(), Rotation2d.fromDegrees(90));
     }
 
     public static final class FieldConstants {
@@ -87,28 +94,34 @@ public final class Constants {
                                 480,
                                 20,
                                 Rotation2d.fromDegrees(70),
-                                new Transform3d()),
+                                new Transform3d(
+                                        new Translation3d(0.33, 0.33, 0.127), new Rotation3d())),
                         new CameraParams(
                                 "FrontRight",
                                 640,
                                 480,
                                 20,
                                 Rotation2d.fromDegrees(70),
-                                new Transform3d()),
+                                new Transform3d(
+                                        new Translation3d(0.33, -0.33, 0.127), new Rotation3d())),
                         new CameraParams(
                                 "BackLeft",
                                 640,
                                 480,
                                 20,
                                 Rotation2d.fromDegrees(70),
-                                new Transform3d()),
+                                new Transform3d(
+                                        new Translation3d(-0.33, -0.33, 0.127),
+                                        new Rotation3d(0.0, 0.0, 3.14))),
                         new CameraParams(
                                 "BackRight",
                                 640,
                                 480,
                                 20,
                                 Rotation2d.fromDegrees(70),
-                                new Transform3d()));
+                                new Transform3d(
+                                        new Translation3d(0.33, -0.33, 0.127),
+                                        new Rotation3d(0.0, 0.0, 3.14))));
 
         public static record CameraParams(
                 String name,
@@ -267,6 +280,13 @@ public final class Constants {
                         Units.inchesToMeters(kBackRightXPosInches),
                         Units.inchesToMeters(kBackRightYPosInches),
                         kInvertRightSide);
+
+        public static final SwerveDriveKinematics kinematics =
+                new SwerveDriveKinematics(
+                        new Translation2d(FrontLeft.LocationX, FrontLeft.LocationY),
+                        new Translation2d(FrontLeft.LocationX, FrontRight.LocationY),
+                        new Translation2d(BackLeft.LocationX, BackLeft.LocationY),
+                        new Translation2d(BackRight.LocationX, BackRight.LocationY));
 
         public static final CommandSwerveDrivetrain DriveTrain =
                 new CommandSwerveDrivetrain(

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -89,7 +89,6 @@ public final class Constants {
         public static final Matrix<N3, N1> driveUncertainty = VecBuilder.fill(0.1, 0.1, 0.1);
 
         // TODO: set up cameras in PhotonVision
-        // spotless:off
         public static final List<CameraParams> cameras =
                 List.of(
                         new CameraParams(
@@ -99,34 +98,33 @@ public final class Constants {
                                 20,
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
-                                        new Translation3d(0.33, 0.33, 0.127), new Rotation3d())));
-                        // new CameraParams(
-                        //         "FrontRight",
-                        //         640,
-                        //         480,
-                        //         20,
-                        //         Rotation2d.fromDegrees(70),
-                        //         new Transform3d(
-                        //                 new Translation3d(0.33, -0.33, 0.127), new Rotation3d())),
-                        // new CameraParams(
-                        //         "BackLeft",
-                        //         640,
-                        //         480,
-                        //         20,
-                        //         Rotation2d.fromDegrees(70),
-                        //         new Transform3d(
-                        //                 new Translation3d(-0.33, -0.33, 0.127),
-                        //                 new Rotation3d(0.0, 0.0, 3.14))),
-                        // new CameraParams(
-                        //         "BackRight",
-                        //         640,
-                        //         480,
-                        //         20,
-                        //         Rotation2d.fromDegrees(70),
-                        //         new Transform3d(
-                        //                 new Translation3d(0.33, -0.33, 0.127),
-                        //                 new Rotation3d(0.0, 0.0, 3.14))));
-                    // spotless:on
+                                        new Translation3d(0.33, 0.33, 0.127), new Rotation3d())),
+                        new CameraParams(
+                                "FrontRight",
+                                640,
+                                480,
+                                20,
+                                Rotation2d.fromDegrees(70),
+                                new Transform3d(
+                                        new Translation3d(0.33, -0.33, 0.127), new Rotation3d())),
+                        new CameraParams(
+                                "BackLeft",
+                                640,
+                                480,
+                                20,
+                                Rotation2d.fromDegrees(70),
+                                new Transform3d(
+                                        new Translation3d(-0.33, -0.33, 0.127),
+                                        new Rotation3d(0.0, 0.0, 3.14))),
+                        new CameraParams(
+                                "BackRight",
+                                640,
+                                480,
+                                20,
+                                Rotation2d.fromDegrees(70),
+                                new Transform3d(
+                                        new Translation3d(0.33, -0.33, 0.127),
+                                        new Rotation3d(0.0, 0.0, 3.14))));
 
         public static record CameraParams(
                 String name,

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -80,12 +80,16 @@ public final class Constants {
 
         public static final double singleTagAmbiguityCutoff = 0.05;
 
-        public static final Matrix<N3, N1> lowCameraUncertainty = VecBuilder.fill(0.45, 0.45, 1);
-        public static final Matrix<N3, N1> highCameraUncertainty = VecBuilder.fill(1.2, 1.2, 10);
+        // 0.45 from 2023
+        public static final Matrix<N3, N1> lowCameraUncertainty = VecBuilder.fill(1.2, 1.2, 2);
+        // 1.2 from 2023
+        public static final Matrix<N3, N1> highCameraUncertainty = VecBuilder.fill(3.5, 3.5, 10);
+        public static final Matrix<N3, N1> singleTagUncertainty = VecBuilder.fill(20.0, 20.0, 10);
 
         public static final Matrix<N3, N1> driveUncertainty = VecBuilder.fill(0.1, 0.1, 0.1);
 
         // TODO: set up cameras in PhotonVision
+        // spotless:off
         public static final List<CameraParams> cameras =
                 List.of(
                         new CameraParams(
@@ -95,33 +99,34 @@ public final class Constants {
                                 20,
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
-                                        new Translation3d(0.33, 0.33, 0.127), new Rotation3d())),
-                        new CameraParams(
-                                "FrontRight",
-                                640,
-                                480,
-                                20,
-                                Rotation2d.fromDegrees(70),
-                                new Transform3d(
-                                        new Translation3d(0.33, -0.33, 0.127), new Rotation3d())),
-                        new CameraParams(
-                                "BackLeft",
-                                640,
-                                480,
-                                20,
-                                Rotation2d.fromDegrees(70),
-                                new Transform3d(
-                                        new Translation3d(-0.33, -0.33, 0.127),
-                                        new Rotation3d(0.0, 0.0, 3.14))),
-                        new CameraParams(
-                                "BackRight",
-                                640,
-                                480,
-                                20,
-                                Rotation2d.fromDegrees(70),
-                                new Transform3d(
-                                        new Translation3d(0.33, -0.33, 0.127),
-                                        new Rotation3d(0.0, 0.0, 3.14))));
+                                        new Translation3d(0.33, 0.33, 0.127), new Rotation3d())));
+                        // new CameraParams(
+                        //         "FrontRight",
+                        //         640,
+                        //         480,
+                        //         20,
+                        //         Rotation2d.fromDegrees(70),
+                        //         new Transform3d(
+                        //                 new Translation3d(0.33, -0.33, 0.127), new Rotation3d())),
+                        // new CameraParams(
+                        //         "BackLeft",
+                        //         640,
+                        //         480,
+                        //         20,
+                        //         Rotation2d.fromDegrees(70),
+                        //         new Transform3d(
+                        //                 new Translation3d(-0.33, -0.33, 0.127),
+                        //                 new Rotation3d(0.0, 0.0, 3.14))),
+                        // new CameraParams(
+                        //         "BackRight",
+                        //         640,
+                        //         480,
+                        //         20,
+                        //         Rotation2d.fromDegrees(70),
+                        //         new Transform3d(
+                        //                 new Translation3d(0.33, -0.33, 0.127),
+                        //                 new Rotation3d(0.0, 0.0, 3.14))));
+                    // spotless:on
 
         public static record CameraParams(
                 String name,

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,8 +1,5 @@
 package frc.robot;
 
-import edu.wpi.first.math.geometry.Pose2d;
-import edu.wpi.first.math.geometry.Rotation2d;
-import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
@@ -105,8 +102,7 @@ public class RobotContainer {
                 tagVision = new VisionLocalizer(new VisionIOReal(VisionConstants.cameras));
                 break;
             case SIM:
-                drivetrain.seedFieldRelative(
-                        new Pose2d(new Translation2d(), Rotation2d.fromDegrees(90)));
+                drivetrain.seedFieldRelative(DriveConstants.initialPose);
 
                 scoringSubsystem =
                         new ScoringSubsystem(
@@ -118,7 +114,7 @@ public class RobotContainer {
                 tagVision =
                         new VisionLocalizer(
                                 new VisionIOSim(
-                                        VisionConstants.cameras, driveTelemetry::getFieldToRobot));
+                                        VisionConstants.cameras, driveTelemetry::getModuleStates));
                 break;
             case REPLAY:
                 break;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -5,6 +5,7 @@ import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.Constants.DriveConstants;
+import frc.robot.Constants.FeatureFlags;
 import frc.robot.Constants.TunerConstants;
 import frc.robot.Constants.VisionConstants;
 import frc.robot.commands.DriveWithJoysticks;
@@ -19,6 +20,7 @@ import frc.robot.subsystems.scoring.HoodIOVortex;
 import frc.robot.subsystems.scoring.ScoringSubsystem;
 import frc.robot.subsystems.scoring.ShooterIOSim;
 import frc.robot.subsystems.scoring.ShooterIOTalon;
+import java.util.Collections;
 
 public class RobotContainer {
     ScoringSubsystem scoringSubsystem;
@@ -111,10 +113,19 @@ public class RobotContainer {
                                 new HoodIOSim(),
                                 driveTelemetry::getFieldToRobot);
 
-                tagVision =
-                        new VisionLocalizer(
-                                new VisionIOSim(
-                                        VisionConstants.cameras, driveTelemetry::getModuleStates));
+                if (FeatureFlags.simulateVision) {
+                    tagVision =
+                            new VisionLocalizer(
+                                    new VisionIOSim(
+                                            VisionConstants.cameras,
+                                            driveTelemetry::getModuleStates));
+                } else {
+                    tagVision =
+                            new VisionLocalizer(
+                                    new VisionIOSim(
+                                            Collections.emptyList(),
+                                            driveTelemetry::getModuleStates));
+                }
                 break;
             case REPLAY:
                 break;

--- a/src/main/java/frc/robot/subsystems/localization/CameraIO.java
+++ b/src/main/java/frc/robot/subsystems/localization/CameraIO.java
@@ -12,6 +12,7 @@ public interface CameraIO {
         public double latestTimestampSeconds = 0.0;
         public double averageTagDistanceM = 0.0;
         public boolean connected = false;
+        public boolean isNew = false;
     }
 
     public default void updateInputs(CameraIOInputs inputs) {}

--- a/src/main/java/frc/robot/subsystems/localization/CameraIO.java
+++ b/src/main/java/frc/robot/subsystems/localization/CameraIO.java
@@ -8,9 +8,10 @@ public interface CameraIO {
     @AutoLog
     public static class CameraIOInputs {
         public Pose2d latestFieldToRobot = new Pose2d();
+        public double averageTagDistanceM = 0.0;
+        public int nTags = 0;
 
         public double latestTimestampSeconds = 0.0;
-        public double averageTagDistanceM = 0.0;
         public boolean connected = false;
         public boolean isNew = false;
     }

--- a/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
+++ b/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
@@ -67,8 +67,10 @@ public class CameraIOPhoton implements CameraIO {
 
         PhotonPipelineResult result = camera.getLatestResult();
         if (result.getTimestampSeconds() == latestTimestampSeconds) {
+            inputs.isNew = false;
             return;
         }
+        inputs.isNew = true;
         latestTimestampSeconds = result.getTimestampSeconds();
         Optional<EstimatedRobotPose> photonPose = poseEstimator.update(result);
 

--- a/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
+++ b/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
@@ -50,6 +50,7 @@ public class CameraIOPhoton implements CameraIO {
         SimCameraProperties props = new SimCameraProperties();
         props.setCalibration(params.xResolution(), params.yResolution(), params.fov());
         props.setFPS(params.fps());
+        props.setCalibError(0.25, 0.08);
 
         PhotonCameraSim cameraSim = new PhotonCameraSim(camera, props);
         sim.addCamera(cameraSim, params.robotToCamera());

--- a/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
+++ b/src/main/java/frc/robot/subsystems/localization/CameraIOPhoton.java
@@ -79,6 +79,7 @@ public class CameraIOPhoton implements CameraIO {
         photonPose.ifPresent(
                 (pose) -> {
                     inputs.latestFieldToRobot = pose.estimatedPose.toPose2d();
+                    inputs.nTags = pose.targetsUsed.size();
 
                     inputs.latestTimestampSeconds = this.latestTimestampSeconds;
                     inputs.averageTagDistanceM = calculateAverageTagDistance(pose);

--- a/src/main/java/frc/robot/subsystems/localization/VisionLocalizer.java
+++ b/src/main/java/frc/robot/subsystems/localization/VisionLocalizer.java
@@ -32,7 +32,7 @@ public class VisionLocalizer extends SubsystemBase {
                     new CameraMeasurement(
                             inputs.latestFieldToRobot,
                             inputs.latestTimestampSeconds,
-                            cameraUncertainty(inputs.averageTagDistanceM)));
+                            cameraUncertainty(inputs.averageTagDistanceM, inputs.nTags)));
         }
 
         Logger.recordOutput("Vision/robotInMidField", robotInMidField());
@@ -46,13 +46,15 @@ public class VisionLocalizer extends SubsystemBase {
         this.fieldToRobotSupplier = fieldToRobotSupplier;
     }
 
-    private Matrix<N3, N1> cameraUncertainty(double averageTagDistanceM) {
+    private Matrix<N3, N1> cameraUncertainty(double averageTagDistanceM, int nTags) {
         /*
          * On this year's field, Apriltags are arranged into rough 'corridors' between the stage and
          * speaker, and a central 'desert,' where few tags can be found. It follows that we should
          * determine the variance of our camera mesurements based on that.
          */
-        if (averageTagDistanceM < 2.0 && this.robotInMidField()) {
+        if (nTags < 1) {
+            return VisionConstants.singleTagUncertainty;
+        } else if (averageTagDistanceM < 2.0 && this.robotInMidField()) {
             return VisionConstants.lowCameraUncertainty;
         } else {
             return VisionConstants.highCameraUncertainty;

--- a/src/main/java/frc/robot/subsystems/localization/VisionLocalizer.java
+++ b/src/main/java/frc/robot/subsystems/localization/VisionLocalizer.java
@@ -48,11 +48,11 @@ public class VisionLocalizer extends SubsystemBase {
 
     private Matrix<N3, N1> cameraUncertainty(double averageTagDistanceM, int nTags) {
         /*
-         * On this year's field, Apriltags are arranged into rough 'corridors' between the stage and
+         * On this year's field, AprilTags are arranged into rough 'corridors' between the stage and
          * speaker, and a central 'desert,' where few tags can be found. It follows that we should
-         * determine the variance of our camera mesurements based on that.
+         * determine the variance of our camera measurements based on that.
          */
-        if (nTags < 1) {
+        if (nTags < 2) {
             return VisionConstants.singleTagUncertainty;
         } else if (averageTagDistanceM < 2.0 && this.robotInMidField()) {
             return VisionConstants.lowCameraUncertainty;


### PR DESCRIPTION
- add (and compensate for) noise to simulated cameras
- add a feature flag to disable vision simulation, as it is performance intensive
- move the simulated cameras to more realistic (but still nonfinal) locations
ref #20