### PR TITLE
Add Rudamentary Intake

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -366,6 +366,8 @@ public final class Constants {
         public static final double aimMaxAngleRadians = Math.PI / 2;
 
         public static final double timeToPutAimDown = 2;
+        public static final double maxAimIntake = 0.0;
+        public static final double minAimIntake = 0.0;
 
         // NOTE - These should be monotonically increasing
         // Key - Distance in meters

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -163,6 +163,11 @@ public final class Constants {
         }
     }
 
+    public static final class IntakeConstants {
+        public static final double intakePower = 5.0;
+        public static final double beltPower = 5.0;
+    }
+
     public static final class EndgameConstants {
         public static final int leftMotorID = 1;
         public static final int rightMotorID = 2;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -17,10 +17,10 @@ import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.subsystems.endgame.EndgameSimIO;
 import frc.robot.subsystems.endgame.EndgameSparkMaxIO;
 import frc.robot.subsystems.endgame.EndgameSubsystem;
-import frc.robot.subsystems.localization.VisionIOReal;
-import frc.robot.subsystems.localization.VisionIOSim;
 import frc.robot.subsystems.intake.IntakeIOSim;
 import frc.robot.subsystems.intake.IntakeSubsystem;
+import frc.robot.subsystems.localization.VisionIOReal;
+import frc.robot.subsystems.localization.VisionIOSim;
 import frc.robot.subsystems.localization.VisionLocalizer;
 import frc.robot.subsystems.scoring.AimerIOSim;
 import frc.robot.subsystems.scoring.AimerIOTalon;
@@ -169,6 +169,12 @@ public class RobotContainer {
         drivetrain.setPoseSupplier(driveTelemetry::getFieldToRobot);
         drivetrain.setSpeakerSupplier(this::getFieldToSpeaker);
         Commands.run(driveTelemetry::logDataSynchronously).ignoringDisable(true).schedule();
+
+        intake.setScoringSupplier(scoringSubsystem::canIntake);
+
+        tagVision.setCameraConsumer(
+                (m) -> drivetrain.addVisionMeasurement(m.pose(), m.timestamp(), m.variance()));
+        tagVision.setFieldToRobotSupplier(driveTelemetry::getFieldToRobot);
     }
 
     public void enabledInit() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -19,6 +19,8 @@ import frc.robot.subsystems.endgame.EndgameSparkMaxIO;
 import frc.robot.subsystems.endgame.EndgameSubsystem;
 import frc.robot.subsystems.localization.VisionIOReal;
 import frc.robot.subsystems.localization.VisionIOSim;
+import frc.robot.subsystems.intake.IntakeIOSim;
+import frc.robot.subsystems.intake.IntakeSubsystem;
 import frc.robot.subsystems.localization.VisionLocalizer;
 import frc.robot.subsystems.scoring.AimerIOSim;
 import frc.robot.subsystems.scoring.AimerIOTalon;
@@ -34,6 +36,8 @@ import org.littletonrobotics.junction.Logger;
 
 public class RobotContainer {
     ScoringSubsystem scoringSubsystem;
+
+    IntakeSubsystem intake;
 
     CommandJoystick leftJoystick = new CommandJoystick(0);
     CommandJoystick rightJoystick = new CommandJoystick(1);
@@ -67,8 +71,11 @@ public class RobotContainer {
 
         controller.a()
                 .onTrue(new InstantCommand(
-                        () -> scoringSubsystem.setAction(
-                                ScoringSubsystem.ScoringAction.INTAKE)));
+                    () -> scoringSubsystem.setAction(
+                        ScoringSubsystem.ScoringAction.INTAKE)))
+                .onTrue(new InstantCommand(
+                    () -> intake.toggle()
+                ));
 
         controller.b()
                 .onTrue(new InstantCommand(
@@ -151,6 +158,8 @@ public class RobotContainer {
                                             driveTelemetry::getModuleStates));
                 }
                 endgameSubsystem = new EndgameSubsystem(new EndgameSimIO());
+
+                intake = new IntakeSubsystem(new IntakeIOSim());
                 break;
             case REPLAY:
                 break;

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -30,6 +30,12 @@ public class Intake extends SubsystemBase {
             case FEEDING:
                 feeding();
                 break;
+            case HOLDING:
+                holding();
+                break;
+            case PASSING:
+                passing();
+                break;
         }
 
         Logger.recordOutput("Intake/running", inputs.backMotorVoltage != 0.0);
@@ -45,7 +51,6 @@ public class Intake extends SubsystemBase {
 
     private void idle() {
         if (shouldBeRunning) {
-            // TODO: if the shooter has a note, don't intake
             state = State.SEEKING;
             io.setIntakeVoltage(5);
         }
@@ -55,19 +60,39 @@ public class Intake extends SubsystemBase {
         if (inputs.backMotorCurrent > 20) {
             state = State.FEEDING;
             io.setIntakeVoltage(2);
+            io.setBeltVolatge(2);
         }
     }
 
     private void feeding() {
         if (inputs.backMotorCurrent < 5) {
-            state = State.IDLE;
+            state = State.HOLDING;
             io.setIntakeVoltage(0);
+            io.setBeltVolatge(0);
         }
     }
 
+    private void holding() {
+        // TODO: interact with shooter
+        /* 
+         * if the shooter is ready to take a note, start the belt and transition
+         * to passing.
+         */
+    }
+
+    private void passing() {
+        // TODO: interact with shooter
+        /*
+         * if the shooter has the note (banner sensor), stop the belt and
+         * return to idle.
+         */
+    }
+
     private enum State {
-        IDLE,
-        SEEKING,
-        FEEDING
+        IDLE, // do nothing
+        SEEKING, // running intake wheels in search of a note
+        FEEDING, // taking in a note and passing it to the belt
+        HOLDING, // holding a note in the belt until the shooter can take it
+        PASSING // moving the belt to pass a note to the shooter
     }
 }

--- a/src/main/java/frc/robot/subsystems/intake/Intake.java
+++ b/src/main/java/frc/robot/subsystems/intake/Intake.java
@@ -1,0 +1,73 @@
+package frc.robot.subsystems.intake;
+
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import org.littletonrobotics.junction.Logger;
+
+public class Intake extends SubsystemBase {
+
+    private IntakeIO io;
+    private IntakeIOInputsAutoLogged inputs = new IntakeIOInputsAutoLogged();
+
+    private State state = State.IDLE;
+
+    private boolean shouldBeRunning = false;
+
+    public Intake(IntakeIO io) {
+        this.io = io;
+    }
+
+    @Override
+    public void periodic() {
+        io.updateInputs(inputs);
+
+        switch (state) {
+            case IDLE:
+                idle();
+                break;
+            case SEEKING:
+                seeking();
+                break;
+            case FEEDING:
+                feeding();
+                break;
+        }
+
+        Logger.recordOutput("Intake/running", inputs.backMotorVoltage != 0.0);
+    }
+
+    public void run(boolean shouldBeRunning) {
+        this.shouldBeRunning = shouldBeRunning;
+    }
+
+    public boolean hasNote() {
+        return state == State.FEEDING;
+    }
+
+    private void idle() {
+        if (shouldBeRunning) {
+            // TODO: if the shooter has a note, don't intake
+            state = State.SEEKING;
+            io.setIntakeVoltage(5);
+        }
+    }
+
+    private void seeking() {
+        if (inputs.backMotorCurrent > 20) {
+            state = State.FEEDING;
+            io.setIntakeVoltage(2);
+        }
+    }
+
+    private void feeding() {
+        if (inputs.backMotorCurrent < 5) {
+            state = State.IDLE;
+            io.setIntakeVoltage(0);
+        }
+    }
+
+    private enum State {
+        IDLE,
+        SEEKING,
+        FEEDING
+    }
+}

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -20,5 +20,5 @@ public interface IntakeIO {
 
     public default void setIntakeVoltage(double volts) {}
 
-    public default void setBeltVolatge(double volts) {}
+    public default void setBeltVoltage(double volts) {}
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -1,0 +1,19 @@
+package frc.robot.subsystems.intake;
+
+import org.littletonrobotics.junction.AutoLog;
+
+public interface IntakeIO {
+
+    @AutoLog
+    public static class IntakeIOInputs {
+        public double frontMotorVoltage = 0.0;
+        public double frontMotorCurrent = 0.0;
+
+        public double backMotorVoltage = 0.0;
+        public double backMotorCurrent = 0.0;
+    }
+
+    public default void updateInputs(IntakeIOInputs inputs) {}
+
+    public default void setIntakeVoltage(double volts) {}
+}

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -11,9 +11,14 @@ public interface IntakeIO {
 
         public double backMotorVoltage = 0.0;
         public double backMotorCurrent = 0.0;
+
+        public double beltMotorVoltage = 0.0;
+        public double beltMotorCurrent = 0.0;
     }
 
     public default void updateInputs(IntakeIOInputs inputs) {}
 
     public default void setIntakeVoltage(double volts) {}
+
+    public default void setBeltVolatge(double volts) {}
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIO.java
@@ -14,6 +14,8 @@ public interface IntakeIO {
 
         public double beltMotorVoltage = 0.0;
         public double beltMotorCurrent = 0.0;
+
+        public boolean noteSensed = false;
     }
 
     public default void updateInputs(IntakeIOInputs inputs) {}

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -1,35 +1,38 @@
 package frc.robot.subsystems.intake;
 
 import edu.wpi.first.math.MathUtil;
-import edu.wpi.first.wpilibj.DigitalInput;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class IntakeIOSim implements IntakeIO {
     /*
      * Simulating the wheels directly doesn't make much sense here, so we can
      * instead use SmartDashboard to puppeteer a note through the indexer
      */
-
     // FIXME: find a more reasonable way to pantomime the intake. Maybe a timer?
-
-    // 10 and 11 aren't valid DIO channels on the real robot
-    private DigitalInput noteInIntakeWheels = new DigitalInput(10);
-    private DigitalInput noteInBelts = new DigitalInput(11);
+    private boolean noteInIntakeWheels = false;
+    private boolean noteInBelts = false;
 
     private double intakeWheelsAppliedVolts = 0.0;
     private double beltAppliedVolts = 0.0;
 
-    public IntakeIOSim() {}
+    public IntakeIOSim() {
+        SmartDashboard.putBoolean("noteInIntake", false);
+        SmartDashboard.putBoolean("noteInBelts", false);
+    }
 
     @Override
     public void updateInputs(IntakeIOInputs inputs) {
+        noteInIntakeWheels = SmartDashboard.getBoolean("noteInIntake", false);
+        noteInBelts = SmartDashboard.getBoolean("noteInBelts", false);
+
         inputs.backMotorVoltage = intakeWheelsAppliedVolts;
-        inputs.backMotorCurrent = noteInIntakeWheels.get() ? 100000 : 0;
+        inputs.backMotorCurrent = noteInIntakeWheels ? 100000 : 0;
 
         inputs.frontMotorVoltage = intakeWheelsAppliedVolts;
-        inputs.frontMotorCurrent = noteInIntakeWheels.get() ? 100000 : 0;
+        inputs.frontMotorCurrent = noteInIntakeWheels ? 100000 : 0;
 
         inputs.beltMotorVoltage = beltAppliedVolts;
-        inputs.beltMotorCurrent = noteInBelts.get() ? 100000 : 0;
+        inputs.beltMotorCurrent = noteInBelts ? 100000 : 0;
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSim.java
@@ -1,0 +1,44 @@
+package frc.robot.subsystems.intake;
+
+import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.DigitalInput;
+
+public class IntakeIOSim implements IntakeIO {
+    /*
+     * Simulating the wheels directly doesn't make much sense here, so we can
+     * instead use SmartDashboard to puppeteer a note through the indexer
+     */
+
+    // FIXME: find a more reasonable way to pantomime the intake. Maybe a timer?
+
+    // 10 and 11 aren't valid DIO channels on the real robot
+    private DigitalInput noteInIntakeWheels = new DigitalInput(10);
+    private DigitalInput noteInBelts = new DigitalInput(11);
+
+    private double intakeWheelsAppliedVolts = 0.0;
+    private double beltAppliedVolts = 0.0;
+
+    public IntakeIOSim() {}
+
+    @Override
+    public void updateInputs(IntakeIOInputs inputs) {
+        inputs.backMotorVoltage = intakeWheelsAppliedVolts;
+        inputs.backMotorCurrent = noteInIntakeWheels.get() ? 100000 : 0;
+
+        inputs.frontMotorVoltage = intakeWheelsAppliedVolts;
+        inputs.frontMotorCurrent = noteInIntakeWheels.get() ? 100000 : 0;
+
+        inputs.beltMotorVoltage = beltAppliedVolts;
+        inputs.beltMotorCurrent = noteInBelts.get() ? 100000 : 0;
+    }
+
+    @Override
+    public void setIntakeVoltage(double volts) {
+        intakeWheelsAppliedVolts = MathUtil.clamp(volts, -12.0, 12.0);
+    }
+
+    @Override
+    public void setBeltVoltage(double volts) {
+        beltAppliedVolts = MathUtil.clamp(volts, -12.0, 12.0);
+    }
+}

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.intake;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import java.util.function.BooleanSupplier;
 import org.littletonrobotics.junction.Logger;
 
 public class IntakeSubsystem extends SubsystemBase {
@@ -9,6 +10,8 @@ public class IntakeSubsystem extends SubsystemBase {
     private IntakeIOInputsAutoLogged inputs = new IntakeIOInputsAutoLogged();
 
     private State state = State.IDLE;
+
+    private BooleanSupplier scorerWantsNote = () -> false;
 
     private boolean shouldBeRunning = false;
 
@@ -40,6 +43,10 @@ public class IntakeSubsystem extends SubsystemBase {
         Logger.recordOutput("intake/belting", inputs.beltMotorVoltage != 0.0);
 
         Logger.recordOutput("intake/state", state.toString());
+    }
+
+    public void setScoringSupplier(BooleanSupplier scorerWantsNote) {
+        this.scorerWantsNote = scorerWantsNote;
     }
 
     public void run(boolean shouldBeRunning) {
@@ -78,17 +85,19 @@ public class IntakeSubsystem extends SubsystemBase {
     }
 
     private void passing() {
-        // TODO: interact with shooter
-        /*
-         * If the shooter is ready to take a note, move the belt. When we don't
-         * have the note anymore, stop and jump to IDLE.
-         */
+        if (scorerWantsNote.getAsBoolean()) {
+            io.setBeltVoltage(2);
+        }
+        if (inputs.beltMotorCurrent < 5) {
+            state = State.IDLE;
+            io.setBeltVoltage(0);
+        }
     }
 
     private enum State {
         IDLE, // do nothing
         SEEKING, // running intake wheels in search of a note
-        FEEDING, // taking in a note and pass it to the belt
+        FEEDING, // taking in a note and passing it to the belt
         PASSING // move the belt to pass the note to the shooter when its ready
     }
 }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -1,6 +1,7 @@
 package frc.robot.subsystems.intake;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants.IntakeConstants;
 import java.util.function.BooleanSupplier;
 import org.littletonrobotics.junction.Logger;
 
@@ -68,12 +69,12 @@ public class IntakeSubsystem extends SubsystemBase {
     private void idle() {
         if (action == IntakeAction.INTAKE) {
             state = State.SEEKING;
-            io.setIntakeVoltage(5);
-            io.setBeltVoltage(5);
+            io.setIntakeVoltage(IntakeConstants.intakePower);
+            io.setBeltVoltage(IntakeConstants.beltPower);
         } else if (action == IntakeAction.REVERSE) {
             state = State.REVERSING;
-            io.setIntakeVoltage(-5);
-            io.setBeltVoltage(-5);
+            io.setIntakeVoltage(-IntakeConstants.intakePower);
+            io.setBeltVoltage(-IntakeConstants.beltPower);
         }
     }
 
@@ -83,15 +84,15 @@ public class IntakeSubsystem extends SubsystemBase {
         }
 
         if (action == IntakeAction.REVERSE) {
-            io.setBeltVoltage(-5);
-            io.setIntakeVoltage(-5);
+            io.setIntakeVoltage(-IntakeConstants.intakePower);
+            io.setBeltVoltage(-IntakeConstants.beltPower);
             state = State.REVERSING;
         }
     }
 
     private void passing() {
         if (scorerWantsNote.getAsBoolean()) {
-            io.setBeltVoltage(2);
+            io.setBeltVoltage(IntakeConstants.beltPower);
         } else {
             io.setBeltVoltage(0);
         }
@@ -101,8 +102,8 @@ public class IntakeSubsystem extends SubsystemBase {
         }
 
         if (action == IntakeAction.REVERSE) {
-            io.setBeltVoltage(-5);
-            io.setIntakeVoltage(-5);
+            io.setIntakeVoltage(-IntakeConstants.intakePower);
+            io.setBeltVoltage(-IntakeConstants.beltPower);
             state = State.REVERSING;
         }
     }

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -3,7 +3,7 @@ package frc.robot.subsystems.intake;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import org.littletonrobotics.junction.Logger;
 
-public class Intake extends SubsystemBase {
+public class IntakeSubsystem extends SubsystemBase {
 
     private IntakeIO io;
     private IntakeIOInputsAutoLogged inputs = new IntakeIOInputsAutoLogged();
@@ -12,13 +12,14 @@ public class Intake extends SubsystemBase {
 
     private boolean shouldBeRunning = false;
 
-    public Intake(IntakeIO io) {
+    public IntakeSubsystem(IntakeIO io) {
         this.io = io;
     }
 
     @Override
     public void periodic() {
         io.updateInputs(inputs);
+        Logger.processInputs("intake", inputs);
 
         switch (state) {
             case IDLE:
@@ -30,19 +31,23 @@ public class Intake extends SubsystemBase {
             case FEEDING:
                 feeding();
                 break;
-            case HOLDING:
-                holding();
-                break;
             case PASSING:
                 passing();
                 break;
         }
 
-        Logger.recordOutput("Intake/running", inputs.backMotorVoltage != 0.0);
+        Logger.recordOutput("intake/running", inputs.backMotorVoltage != 0.0);
+        Logger.recordOutput("intake/belting", inputs.beltMotorVoltage != 0.0);
+
+        Logger.recordOutput("intake/state", state.toString());
     }
 
     public void run(boolean shouldBeRunning) {
         this.shouldBeRunning = shouldBeRunning;
+    }
+
+    public void toggle() {
+        shouldBeRunning = !shouldBeRunning;
     }
 
     public boolean hasNote() {
@@ -60,39 +65,30 @@ public class Intake extends SubsystemBase {
         if (inputs.backMotorCurrent > 20) {
             state = State.FEEDING;
             io.setIntakeVoltage(2);
-            io.setBeltVolatge(2);
+            io.setBeltVoltage(2);
         }
     }
 
     private void feeding() {
         if (inputs.backMotorCurrent < 5) {
-            state = State.HOLDING;
+            state = State.PASSING;
             io.setIntakeVoltage(0);
-            io.setBeltVolatge(0);
+            io.setBeltVoltage(0);
         }
-    }
-
-    private void holding() {
-        // TODO: interact with shooter
-        /* 
-         * if the shooter is ready to take a note, start the belt and transition
-         * to passing.
-         */
     }
 
     private void passing() {
         // TODO: interact with shooter
         /*
-         * if the shooter has the note (banner sensor), stop the belt and
-         * return to idle.
+         * If the shooter is ready to take a note, move the belt. When we don't
+         * have the note anymore, stop and jump to IDLE.
          */
     }
 
     private enum State {
         IDLE, // do nothing
         SEEKING, // running intake wheels in search of a note
-        FEEDING, // taking in a note and passing it to the belt
-        HOLDING, // holding a note in the belt until the shooter can take it
-        PASSING // moving the belt to pass a note to the shooter
+        FEEDING, // taking in a note and pass it to the belt
+        PASSING // move the belt to pass the note to the shooter when its ready
     }
 }


### PR DESCRIPTION
I've written a basic intake subsystem and some code to puppeteer a simulated note through the intake/indexer system. 

In the future, I would prefer to use a timer of some kind to simulate the movement of a note

Closes #46