### PR TITLE
Avoid Simulator Crash and Un-Break Telemetry

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -3,7 +3,6 @@ package frc.robot;
 import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Translation2d;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.InstantCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandJoystick;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
@@ -168,7 +167,6 @@ public class RobotContainer {
         drivetrain.registerTelemetry(driveTelemetry::telemeterize);
         drivetrain.setPoseSupplier(driveTelemetry::getFieldToRobot);
         drivetrain.setSpeakerSupplier(this::getFieldToSpeaker);
-        Commands.run(driveTelemetry::logDataSynchronously).ignoringDisable(true).schedule();
 
         intake.setScoringSupplier(scoringSubsystem::canIntake);
 
@@ -221,5 +219,7 @@ public class RobotContainer {
                 FieldFinder.whereAmI(
                         driveTelemetry.getFieldToRobot().getTranslation().getX(),
                         driveTelemetry.getFieldToRobot().getTranslation().getY()));
+
+        driveTelemetry.logDataSynchronously();
     }
 }

--- a/src/main/java/frc/robot/subsystems/endgame/EndgameSimIO.java
+++ b/src/main/java/frc/robot/subsystems/endgame/EndgameSimIO.java
@@ -1,7 +1,6 @@
 package frc.robot.subsystems.endgame;
 
 import com.revrobotics.CANSparkMax;
-import frc.robot.Constants.EndgameConstants;
 
 public class EndgameSimIO implements EndgameIO {
     private CANSparkMax leftEndgameMotor, rightEndgameMotor;
@@ -23,24 +22,35 @@ public class EndgameSimIO implements EndgameIO {
     }
 
     public void setEndgameMotorPower(double leftPercent, double rightPercent) {
-        rightEndgameMotor.set(-rightPercent);
-        leftEndgameMotor.set(-leftPercent);
+        // no-op to avoid a crash until an ElevatorSim is implemented
+
+        // rightEndgameMotor.set(-rightPercent);
+        // leftEndgameMotor.set(-leftPercent);
     }
 
     public double getRightEndgameMotorAmps() {
-        return rightEndgameMotor.getOutputCurrent();
+        // no-op to avoid a crash until an ElevatorSim is implemented
+
+        // return rightEndgameMotor.getOutputCurrent();
+        return 0;
     }
 
     public double getLeftEndgameMotorAmps() {
-        return leftEndgameMotor.getOutputCurrent();
+        // return leftEndgameMotor.getOutputCurrent();
+        // no-op to avoid a crash until an ElevatorSim is implemented
+        return 0;
     }
 
     public double getRightEndgamePosition() {
-        return rightEndgameMotor.getEncoder().getPosition() / EndgameConstants.ticksPerFoot;
+        // return rightEndgameMotor.getEncoder().getPosition() / EndgameConstants.ticksPerFoot;
+        // no-op to avoid a crash until an ElevatorSim is implemented
+        return 0;
     }
 
     public double getLeftEndgamePosition() {
-        return leftEndgameMotor.getEncoder().getPosition() / EndgameConstants.ticksPerFoot;
+        // return leftEndgameMotor.getEncoder().getPosition() / EndgameConstants.ticksPerFoot;
+        // no-op to avoid a crash until an ElevatorSim is implemented
+        return 0;
     }
 
     public void checkEndgameAmps() {


### PR DESCRIPTION
Currently, `main` crashes when simulated, and doesn't log drive telemetry correctly. This should fix it.