### PR TITLE
Add bounds checking to InterpolateDouble

### DIFF
--- a/src/main/java/frc/robot/utils/InterpolateDouble.java
+++ b/src/main/java/frc/robot/utils/InterpolateDouble.java
@@ -49,9 +49,9 @@ public class InterpolateDouble {
 
         // Ensure that key is within the bounds of the HashMap
         if (key < minKey) {
-            return minValue;
+            return map.get(minKey);
         } else if (key > maxKey) {
-            return maxValue;
+            return map.get(maxKey);
         }
 
         double lowerKey = 0;

--- a/src/main/java/frc/robot/utils/InterpolateDouble.java
+++ b/src/main/java/frc/robot/utils/InterpolateDouble.java
@@ -11,6 +11,9 @@ public class InterpolateDouble {
     private final double minValue;
     private final double maxValue;
 
+    private final double minKey;
+    private final double maxKey;
+
     public InterpolateDouble(HashMap<Double, Double> map) {
         this(map, Double.MIN_VALUE, Double.MAX_VALUE);
     }
@@ -22,6 +25,14 @@ public class InterpolateDouble {
 
         sortedKeys = new ArrayList<Double>(map.keySet());
         Collections.sort(sortedKeys);
+
+        // Get lowest and highest keys of the HashMap
+        if (sortedKeys.size() > 0) {
+            minKey = sortedKeys.get(0);
+            maxKey = sortedKeys.get(sortedKeys.size() - 1);
+        } else {
+            throw new RuntimeException("Empty HashMap passed to InterpolateDouble");
+        }
     }
 
     /**
@@ -34,6 +45,13 @@ public class InterpolateDouble {
     public double getValue(double key) {
         if (map.containsKey(key)) {
             return map.get(key);
+        }
+
+        // Ensure that key is within the bounds of the HashMap
+        if (key < minKey) {
+            return minValue;
+        } else if (key > maxKey) {
+            return maxValue;
         }
 
         double lowerKey = 0;


### PR DESCRIPTION
Upon initialization, InterpolateDouble now grabs the lowest and highest keys of the HashMap. When getValue is called, the key is checked, and, if it is less than the lowest key, the lowest value is returned. If it is higher than the highest key, the highest value is returned. Otherwise, the function continues as it would have before.

I wasn't sure how to handle an empty HashMap (at least 1 key is required to get bounds), so for now it just raises a RuntimeException. I can update this as needed.