### PR TITLE
Match the Button Binding Spreadsheet

### DIFF
--- a/src/main/deploy/pathplanner/paths/New Path.path
+++ b/src/main/deploy/pathplanner/paths/New Path.path
@@ -1,0 +1,58 @@
+{
+  "version": 1.0,
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 1.8175927319320395,
+        "y": 7.543619911726125
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 3.924497587865042,
+        "y": 7.873410648362394
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 4.0,
+        "y": 6.0
+      },
+      "prevControl": {
+        "x": 3.0,
+        "y": 6.0
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [
+    {
+      "waypointRelativePos": 0,
+      "rotationDegrees": 0,
+      "rotateFast": false
+    }
+  ],
+  "constraintZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 4.5,
+    "maxAcceleration": 2.75,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 0,
+    "rotateFast": false
+  },
+  "reversed": false,
+  "folder": null,
+  "previewStartingState": {
+    "rotation": 89.69981140519788,
+    "velocity": 0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -103,9 +103,9 @@ public final class Constants {
         public static final Rotation2d fieldToAmpHeading = new Rotation2d(-Math.PI / 2);
 
         public static final Rotation2d fieldToRedSourceHeading =
-                new Rotation2d(Math.PI / 3); // 60 degrees
+                new Rotation2d(Math.PI / 3 + Math.PI); // 60 degrees
         public static final Rotation2d fieldToBlueSourceHeading =
-                new Rotation2d(Math.PI * 2 / 3); // 120 degrees
+                new Rotation2d(Math.PI * 2 / 3 + Math.PI); // 120 degrees
 
         public static final Translation2d fieldToRedSpeaker =
                 new Translation2d(Units.inchesToMeters(652.73), Units.inchesToMeters(218.42));
@@ -206,7 +206,7 @@ public final class Constants {
         public static final int indexTwoMotorID = 14;
 
         public static final double intakePower = 10.0;
-        public static final double beltPower = 10.0;
+        public static final double beltPower = 8.0;
     }
 
     public static final class EndgameConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,7 +46,7 @@ public final class Constants {
     }
 
     public static final class FeatureFlags {
-        public static final boolean runVision = false;
+        public static final boolean runVision = true;
 
         public static final boolean runIntake = true;
         public static final boolean runScoring = true;
@@ -144,7 +144,7 @@ public final class Constants {
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
                                         new Translation3d(0.323, 0.262, 0.216),
-                                        new Rotation3d(0.0, 1.224, 0.138))),
+                                        new Rotation3d(0, -0.349, 0.138))),
                         new CameraParams(
                                 "Front-Right",
                                 640,
@@ -153,7 +153,7 @@ public final class Constants {
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
                                         new Translation3d(0.323, -0.262, 0.216),
-                                        new Rotation3d(0.0, 1.224, -0.138))),
+                                        new Rotation3d(0.0, -0.349, -0.138))),
                         new CameraParams(
                                 "Back-Left",
                                 640,
@@ -162,7 +162,7 @@ public final class Constants {
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
                                         new Translation3d(-0.327, 0.281, 0.333),
-                                        new Rotation3d(0.0, -1.162, 3.14))),
+                                        new Rotation3d(0.0, -0.409, 3.14))),
                         new CameraParams(
                                 "Back-Right",
                                 640,
@@ -171,7 +171,7 @@ public final class Constants {
                                 Rotation2d.fromDegrees(70),
                                 new Transform3d(
                                         new Translation3d(-0.327, -0.281, 0.333),
-                                        new Rotation3d(0.0, -1.162, 3.14))));
+                                        new Rotation3d(0.0, -0.409, 3.14))));
 
         public static record CameraParams(
                 String name,

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -89,7 +89,7 @@ public final class Constants {
 
         public static final double alignmentkPMax = 7.0;
         public static final double alignmentkPMin = 5.0;
-        public static final double alignmentkI = 1.0;
+        public static final double alignmentkI = 2.0;
         public static final double alignmentkD = 0.0;
     }
 
@@ -124,6 +124,12 @@ public final class Constants {
 
         public static final Pose2d robotAgainstRedPodium =
                 new Pose2d(13.93, 4.09, Rotation2d.fromDegrees(0));
+
+        public static final Pose2d robotAgainstBlueAmpZone =
+                new Pose2d(2.85, 7.68, Rotation2d.fromDegrees(-90));
+
+        public static final Pose2d robotAgainstRedAmpZone =
+                new Pose2d(13.74, 7.68, Rotation2d.fromDegrees(-90));
     }
 
     public static final class VisionConstants {
@@ -442,7 +448,7 @@ public final class Constants {
         public static final double aimAngleMarginRadians = Units.degreesToRadians(1);
         public static final double hoodAngleMarginRadians = Units.degreesToRadians(5);
 
-        public static final double intakeAngleToleranceRadians = 0.0;
+        public static final double intakeAngleToleranceRadians = 0.1;
         // Math.PI / 2 - Units.degreesToRadians(40);
 
         public static final double shooterAmpVelocityRPM = 2000;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -100,12 +100,12 @@ public final class Constants {
         public static final double midfieldLowThresholdM = 5.87;
         public static final double midfieldHighThresholdM = 10.72;
 
-        public static final Rotation2d fieldToAmpHeading = new Rotation2d(-Math.PI / 2);
+        public static final Rotation2d ampHeading = new Rotation2d(-Math.PI / 2);
 
-        public static final Rotation2d fieldToRedSourceHeading =
-                new Rotation2d(Math.PI / 3 + Math.PI); // 60 degrees
-        public static final Rotation2d fieldToBlueSourceHeading =
-                new Rotation2d(Math.PI * 2 / 3 + Math.PI); // 120 degrees
+        public static final Rotation2d redSourceHeading =
+                new Rotation2d(Math.PI * 4 / 3); // 60 degrees
+        public static final Rotation2d blueSourceHeading =
+                new Rotation2d(Math.PI * 5 / 3); // 120 degrees
 
         public static final Translation2d fieldToRedSpeaker =
                 new Translation2d(Units.inchesToMeters(652.73), Units.inchesToMeters(218.42));
@@ -118,6 +118,12 @@ public final class Constants {
 
         public static final Pose2d robotAgainstRedSpeaker =
                 new Pose2d(15.19, 5.56, Rotation2d.fromDegrees(0));
+
+        public static final Pose2d robotAgainstBluePodium =
+                new Pose2d(2.57, 4.09, Rotation2d.fromDegrees(180));
+
+        public static final Pose2d robotAgainstRedPodium =
+                new Pose2d(13.93, 4.09, Rotation2d.fromDegrees(0));
     }
 
     public static final class VisionConstants {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -238,19 +238,15 @@ public class RobotContainer {
                     () -> drivetrain.seedFieldRelative(getPoseAgainstSpeaker()))
                 );
 
-            controller.b()
+            controller.povUp()
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignTarget(AlignTarget.SPEAKER)));
 
-            controller.start()
+            controller.rightBumper()
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignTarget(AlignTarget.SPEAKER)));
 
-            controller.x()
-                .onTrue(new InstantCommand(
-                    () -> drivetrain.setAlignTarget(AlignTarget.SPEAKER)));
-
-            controller.back()
+            controller.povRight()
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignTarget(AlignTarget.AMP)));
 
@@ -260,33 +256,31 @@ public class RobotContainer {
         if (FeatureFlags.runEndgame) {
             endgameSubsystem.setAction(EndgameSubsystem.EndgameAction.OVERRIDE);
 
-            controller.povUp()
+            controller.leftBumper()
                 .onTrue(new InstantCommand(() -> endgameSubsystem.setVolts(2.0, 0)))
                 .onFalse(new InstantCommand(() -> endgameSubsystem.setVolts(0.0, 0)));
 
-            controller.povDown()
+            controller.leftTrigger()
                 .onTrue(new InstantCommand(() -> endgameSubsystem.setVolts(-2.0, 0)))
                 .onFalse(new InstantCommand(() -> endgameSubsystem.setVolts(0.0, 0)));
         }
 
         if (FeatureFlags.runIntake) {
-            controller.a()
+            controller.b()
                 .onTrue(new InstantCommand(
                         () -> intakeSubsystem.run(IntakeAction.INTAKE)))
                 .onFalse(new InstantCommand(
                     () -> intakeSubsystem.run(IntakeAction.NONE)));
 
-            controller.rightBumper()
+            controller.a()
                 .onTrue(new InstantCommand(
-                        () -> intakeSubsystem.run(IntakeAction.REVERSE)));
-                
-            controller.start()
-                .onTrue(new InstantCommand(
-                        () -> intakeSubsystem.run(IntakeAction.NONE)));
+                    () -> intakeSubsystem.run(IntakeAction.REVERSE)))
+                .onFalse(new InstantCommand(
+                    () -> intakeSubsystem.run(IntakeAction.NONE)));
         }
 
         if (FeatureFlags.runScoring) {
-            controller.a()
+            controller.b()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.INTAKE)))
@@ -294,32 +288,40 @@ public class RobotContainer {
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.WAIT)));
 
-            controller.b()
+            controller.a()
+                .onTrue(new InstantCommand(
+                    () -> scoringSubsystem.setAction(
+                        ScoringSubsystem.ScoringAction.SPIT)))
+                .onFalse(new InstantCommand(
+                    () -> scoringSubsystem.setAction(
+                        ScoringSubsystem.ScoringAction.WAIT)));
+
+            controller.povUp()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                          ScoringSubsystem.ScoringAction.AIM)));
 
-            controller.x()
+            controller.rightBumper()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.SHOOT)));
 
-            controller.y()
+            controller.povLeft()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.ENDGAME)));
 
-            controller.back()
+            controller.povRight()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.AMP_AIM)));
 
-            controller.start()
+            controller.povDown()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.WAIT)));
 
-            controller.povLeft()
+            controller.y()
                 .onTrue(new InstantCommand(
                     () -> scoringSubsystem.setAction(
                         ScoringSubsystem.ScoringAction.SOURCE_INTAKE)))

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -238,9 +238,13 @@ public class RobotContainer {
                 .onTrue(new InstantCommand(
                     () -> drivetrain.seedFieldRelative(getPoseAgainstSpeaker())));
             
-            leftJoystick.button(1) // placeholder button
+            leftJoystick.button(3)
                 .onTrue(new InstantCommand(
                     () -> drivetrain.seedFieldRelative(getPoseAgainstPodium())));
+
+            leftJoystick.button(4)
+                .onTrue(new InstantCommand(
+                    () -> drivetrain.seedFieldRelative(getPoseAgainstAmpZone())));
 
             controller.povUp()
                 .onTrue(new InstantCommand(
@@ -288,7 +292,9 @@ public class RobotContainer {
         if (FeatureFlags.runScoring) {
             scoringSubsystem.setDefaultCommand(new ShootWithGamepad(
                 rightJoystick.getHID()::getTrigger,
+                () -> rightJoystick.getHID().getRawButton(4),
                 controller.getHID()::getRightBumper,
+                controller.getHID()::getYButton,
                 () -> controller.getRightTriggerAxis() > 0.5,
                 controller.getHID()::getAButton,
                 controller.getHID()::getBButton, scoringSubsystem,
@@ -606,6 +612,18 @@ public class RobotContainer {
             }
         }
         return FieldConstants.robotAgainstRedPodium;
+    }
+
+    private Pose2d getPoseAgainstAmpZone() {
+        if (!DriverStation.getAlliance().isEmpty()) {
+            switch (DriverStation.getAlliance().get()) {
+                case Blue:
+                    return FieldConstants.robotAgainstRedAmpZone;
+                case Red:
+                    return FieldConstants.robotAgainstBlueAmpZone;
+            }
+        }
+        return FieldConstants.robotAgainstRedAmpZone;
     }
 
     private Rotation2d getFieldToSourceHeading() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -228,7 +228,7 @@ public class RobotContainer {
         if (FeatureFlags.runDrive) {
             setUpDriveWithJoysticks();
                 
-            rightJoystick.trigger()
+            leftJoystick.trigger()
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignState(AlignState.ALIGNING)))
                 .onFalse(new InstantCommand(
@@ -284,10 +284,11 @@ public class RobotContainer {
 
         if (FeatureFlags.runScoring) {
             scoringSubsystem.setDefaultCommand(new ShootWithGamepad(
-                rightJoystick.getHID()::getTop,
+                rightJoystick.getHID()::getTrigger,
                 controller.getHID()::getRightBumper,
                 () -> controller.getRightTriggerAxis() > 0.5,
-                controller.getHID()::getAButton, scoringSubsystem,
+                controller.getHID()::getAButton,
+                controller.getHID()::getBButton, scoringSubsystem,
                 FeatureFlags.runDrive ? drivetrain::getAlignTarget : () -> AlignTarget.NONE));
         }
     } // spotless:on
@@ -620,7 +621,7 @@ public class RobotContainer {
                             () -> rightJoystick.getX(),
                             () -> controller.getHID().getPOV(),
                             () -> true,
-                            () -> leftJoystick.trigger().getAsBoolean(),
+                            () -> rightJoystick.top().getAsBoolean(),
                             () -> rightJoystick.trigger().getAsBoolean()));
         }
     }
@@ -652,11 +653,19 @@ public class RobotContainer {
     public void disabledPeriodic() {
         /* set to coast mode when circuit open */
         if (brakeSwitch != null && brakeSwitch.get()) {
-            scoringSubsystem.setBrakeMode(false);
-            endgameSubsystem.setBrakeMode(false);
+            if (FeatureFlags.runScoring) {
+                scoringSubsystem.setBrakeMode(false);
+            }
+            if (FeatureFlags.runEndgame) {
+                endgameSubsystem.setBrakeMode(false);
+            }
         } else {
-            scoringSubsystem.setBrakeMode(true);
-            endgameSubsystem.setBrakeMode(true);
+            if (FeatureFlags.runScoring) {
+                scoringSubsystem.setBrakeMode(true);
+            }
+            if (FeatureFlags.runEndgame) {
+                endgameSubsystem.setBrakeMode(true);
+            }
         }
     }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -236,8 +236,11 @@ public class RobotContainer {
 
             leftJoystick.top()
                 .onTrue(new InstantCommand(
-                    () -> drivetrain.seedFieldRelative(getPoseAgainstSpeaker()))
-                );
+                    () -> drivetrain.seedFieldRelative(getPoseAgainstSpeaker())));
+            
+            leftJoystick.button(1) // placeholder button
+                .onTrue(new InstantCommand(
+                    () -> drivetrain.seedFieldRelative(getPoseAgainstPodium())));
 
             controller.povUp()
                 .onTrue(new InstantCommand(
@@ -577,14 +580,12 @@ public class RobotContainer {
     }
 
     private Rotation2d getFieldToAmpHeading() {
-        Logger.recordOutput("Field/amp", FieldConstants.fieldToAmpHeading);
-        return FieldConstants.fieldToAmpHeading;
+        Logger.recordOutput("Field/amp", FieldConstants.ampHeading);
+        return FieldConstants.ampHeading;
     }
 
     private Pose2d getPoseAgainstSpeaker() {
-        if (DriverStation.getAlliance().isEmpty()) {
-            return FieldConstants.robotAgainstRedSpeaker;
-        } else {
+        if (!DriverStation.getAlliance().isEmpty()) {
             switch (DriverStation.getAlliance().get()) {
                 case Blue:
                     return FieldConstants.robotAgainstBlueSpeaker;
@@ -592,23 +593,33 @@ public class RobotContainer {
                     return FieldConstants.robotAgainstRedSpeaker;
             }
         }
-        throw new RuntimeException("Unreachable branch of switch expression");
+        return FieldConstants.robotAgainstRedSpeaker;
+    }
+
+    private Pose2d getPoseAgainstPodium() {
+        if (!DriverStation.getAlliance().isEmpty()) {
+            switch (DriverStation.getAlliance().get()) {
+                case Blue:
+                    return FieldConstants.robotAgainstBluePodium;
+                case Red:
+                    return FieldConstants.robotAgainstRedPodium;
+            }
+        }
+        return FieldConstants.robotAgainstRedPodium;
     }
 
     private Rotation2d getFieldToSourceHeading() {
-        if (DriverStation.getAlliance().isEmpty()) {
-            return FieldConstants.fieldToRedSourceHeading;
-        } else {
+        if (!DriverStation.getAlliance().isEmpty()) {
             switch (DriverStation.getAlliance().get()) {
                 case Blue:
-                    Logger.recordOutput("Field/source", FieldConstants.fieldToBlueSourceHeading);
-                    return FieldConstants.fieldToBlueSourceHeading;
+                    Logger.recordOutput("Field/source", FieldConstants.blueSourceHeading);
+                    return FieldConstants.blueSourceHeading;
                 case Red:
-                    Logger.recordOutput("Field/source", FieldConstants.fieldToRedSourceHeading);
-                    return FieldConstants.fieldToRedSourceHeading;
+                    Logger.recordOutput("Field/source", FieldConstants.redSourceHeading);
+                    return FieldConstants.redSourceHeading;
             }
         }
-        throw new RuntimeException("Unreachable branch of switch expression");
+        return FieldConstants.redSourceHeading;
     }
 
     private void setUpDriveWithJoysticks() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -22,6 +22,7 @@ import frc.robot.Constants.ScoringConstants;
 import frc.robot.Constants.TunerConstants;
 import frc.robot.Constants.VisionConstants;
 import frc.robot.commands.DriveWithJoysticks;
+import frc.robot.commands.ShootWithGamepad;
 import frc.robot.subsystems.LED;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain.AlignState;
@@ -242,15 +243,17 @@ public class RobotContainer {
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignTarget(AlignTarget.SPEAKER)));
 
-            controller.rightBumper()
-                .onTrue(new InstantCommand(
-                    () -> drivetrain.setAlignTarget(AlignTarget.SPEAKER)));
-
             controller.povRight()
                 .onTrue(new InstantCommand(
                     () -> drivetrain.setAlignTarget(AlignTarget.AMP)));
 
-            // controller.povRight().onTrue(drivetrain.getDriveToPointCommand());
+            controller.povLeft()
+                .onTrue(new InstantCommand(
+                    () -> drivetrain.setAlignTarget(AlignTarget.SOURCE)));
+
+            controller.povDown()
+                .onTrue(new InstantCommand(
+                    () -> drivetrain.setAlignTarget(AlignTarget.ENDGAME)));
         }
 
         if (FeatureFlags.runEndgame) {
@@ -280,54 +283,12 @@ public class RobotContainer {
         }
 
         if (FeatureFlags.runScoring) {
-            controller.b()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.INTAKE)))
-                .onFalse(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.WAIT)));
-
-            controller.a()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.SPIT)))
-                .onFalse(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.WAIT)));
-
-            controller.povUp()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                         ScoringSubsystem.ScoringAction.AIM)));
-
-            controller.rightBumper()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.SHOOT)));
-
-            controller.povLeft()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.ENDGAME)));
-
-            controller.povRight()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.AMP_AIM)));
-
-            controller.povDown()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.WAIT)));
-
-            controller.y()
-                .onTrue(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.SOURCE_INTAKE)))
-                .onFalse(new InstantCommand(
-                    () -> scoringSubsystem.setAction(
-                        ScoringSubsystem.ScoringAction.WAIT)));
+            scoringSubsystem.setDefaultCommand(new ShootWithGamepad(
+                rightJoystick.getHID()::getTop,
+                controller.getHID()::getRightBumper,
+                () -> controller.getRightTriggerAxis() > 0.5,
+                controller.getHID()::getAButton, scoringSubsystem,
+                FeatureFlags.runDrive ? drivetrain::getAlignTarget : () -> AlignTarget.NONE));
         }
     } // spotless:on
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -630,10 +630,8 @@ public class RobotContainer {
                             () -> leftJoystick.getY(),
                             () -> leftJoystick.getX(),
                             () -> rightJoystick.getX(),
-                            () -> controller.getHID().getPOV(),
                             () -> true,
-                            () -> rightJoystick.top().getAsBoolean(),
-                            () -> rightJoystick.trigger().getAsBoolean()));
+                            () -> rightJoystick.top().getAsBoolean()));
         }
     }
 

--- a/src/main/java/frc/robot/commands/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/DriveWithJoysticks.java
@@ -71,13 +71,13 @@ public class DriveWithJoysticks extends Command {
         double[] joystickInputsFiltered =
                 Deadband.twoAxisDeadband(allianceX, allianceY, DriveConstants.deadbandPercent);
 
-        joystickInputsFiltered[0] = Math.pow(joystickInputsFiltered[0], 3);
-        joystickInputsFiltered[1] = Math.pow(joystickInputsFiltered[1], 3);
+        joystickInputsFiltered[0] = Math.pow(joystickInputsFiltered[0], 1);
+        joystickInputsFiltered[1] = Math.pow(joystickInputsFiltered[1], 1);
 
         xMpS = joystickInputsFiltered[0] * DriveConstants.MaxSpeedMetPerSec;
         yMpS = joystickInputsFiltered[1] * DriveConstants.MaxSpeedMetPerSec;
         rotRadpS = Deadband.oneAxisDeadband(rot.getAsDouble(), DriveConstants.deadbandPercent);
-        rotRadpS = Math.pow(rotRadpS, 3) * DriveConstants.MaxAngularRateRadiansPerSec;
+        rotRadpS = Math.pow(rotRadpS, 1) * DriveConstants.MaxAngularRateRadiansPerSec;
 
         if (babyMode.getAsBoolean()) {
             xMpS *= 0.5;

--- a/src/main/java/frc/robot/commands/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/DriveWithJoysticks.java
@@ -5,21 +5,17 @@ import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
-import frc.robot.subsystems.drive.CommandSwerveDrivetrain.AlignTarget;
 import frc.robot.utils.Deadband;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
-import java.util.function.IntSupplier;
 
 public class DriveWithJoysticks extends Command {
     CommandSwerveDrivetrain drivetrain;
     DoubleSupplier x;
     DoubleSupplier y;
     DoubleSupplier rot;
-    IntSupplier POV;
     BooleanSupplier fieldCentric;
     BooleanSupplier babyMode;
-    BooleanSupplier autoAlign;
 
     double xMpS;
     double yMpS;
@@ -30,18 +26,14 @@ public class DriveWithJoysticks extends Command {
             DoubleSupplier x,
             DoubleSupplier y,
             DoubleSupplier rot,
-            IntSupplier POV,
             BooleanSupplier fieldCentric,
-            BooleanSupplier babyMode,
-            BooleanSupplier autoAlign) {
+            BooleanSupplier babyMode) {
         this.drivetrain = drivetrain;
         this.x = x;
         this.y = y;
-        this.POV = POV;
         this.rot = rot;
         this.fieldCentric = fieldCentric;
         this.babyMode = babyMode;
-        this.autoAlign = autoAlign;
 
         addRequirements(drivetrain);
     }
@@ -83,26 +75,6 @@ public class DriveWithJoysticks extends Command {
             xMpS *= 0.5;
             yMpS *= 0.5;
             rotRadpS *= 0.5;
-        }
-
-        // drivetrain.setAlignState(
-        //         autoAlign.getAsBoolean() ? AlignState.ALIGNING : AlignState.MANUAL);
-
-        switch (POV.getAsInt()) {
-            case 0:
-                drivetrain.setAlignTarget(AlignTarget.SPEAKER);
-                break;
-            case 90:
-                drivetrain.setAlignTarget(AlignTarget.AMP);
-                break;
-            case 180:
-                drivetrain.setAlignTarget(AlignTarget.NONE);
-                break;
-            case 270:
-                drivetrain.setAlignTarget(AlignTarget.SOURCE);
-                break;
-            default:
-                break;
         }
 
         drivetrain.setGoalChassisSpeeds(

--- a/src/main/java/frc/robot/commands/DriveWithJoysticks.java
+++ b/src/main/java/frc/robot/commands/DriveWithJoysticks.java
@@ -1,6 +1,7 @@
 package frc.robot.commands;
 
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.DriveConstants;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
@@ -50,9 +51,25 @@ public class DriveWithJoysticks extends Command {
 
     @Override
     public void execute() {
+        double allianceX = 0.0;
+        double allianceY = 0.0;
+        if (DriverStation.getAlliance().isPresent()) {
+            switch (DriverStation.getAlliance().get()) {
+                case Red:
+                    allianceX = x.getAsDouble();
+                    allianceY = y.getAsDouble();
+                    break;
+                case Blue:
+                    allianceX = -x.getAsDouble();
+                    allianceY = -y.getAsDouble();
+                    break;
+            }
+        } else {
+            allianceX = x.getAsDouble();
+            allianceY = y.getAsDouble();
+        }
         double[] joystickInputsFiltered =
-                Deadband.twoAxisDeadband(
-                        x.getAsDouble(), y.getAsDouble(), DriveConstants.deadbandPercent);
+                Deadband.twoAxisDeadband(allianceX, allianceY, DriveConstants.deadbandPercent);
 
         joystickInputsFiltered[0] = Math.pow(joystickInputsFiltered[0], 3);
         joystickInputsFiltered[1] = Math.pow(joystickInputsFiltered[1], 3);

--- a/src/main/java/frc/robot/commands/ShootWithGamepad.java
+++ b/src/main/java/frc/robot/commands/ShootWithGamepad.java
@@ -1,0 +1,78 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.drive.CommandSwerveDrivetrain.AlignTarget;
+import frc.robot.subsystems.scoring.ScoringSubsystem;
+import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringAction;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public class ShootWithGamepad extends Command {
+
+    private BooleanSupplier driverShoot;
+    private BooleanSupplier masherShoot;
+    private BooleanSupplier warmup;
+    private BooleanSupplier reverseIntake;
+
+    private ScoringSubsystem scoring;
+
+    private Supplier<AlignTarget> getDriveMode;
+
+    public ShootWithGamepad(
+            BooleanSupplier driverShoot,
+            BooleanSupplier masherShoot,
+            BooleanSupplier warmup,
+            BooleanSupplier reverseIntake,
+            ScoringSubsystem scoring,
+            Supplier<AlignTarget> getDriveMode) {
+        this.driverShoot = driverShoot;
+        this.masherShoot = masherShoot;
+        this.warmup = warmup;
+        this.reverseIntake = reverseIntake;
+
+        this.scoring = scoring;
+        this.getDriveMode = getDriveMode;
+
+        addRequirements(scoring);
+    }
+
+    @Override
+    public void initialize() {}
+
+    @Override
+    public void execute() {
+        if (warmup.getAsBoolean()) {
+            switch (getDriveMode.get()) {
+                case NONE:
+                    scoring.setAction(ScoringAction.WAIT);
+                    break;
+                case SPEAKER:
+                    scoring.setAction(ScoringAction.AIM);
+                    break;
+                case AMP:
+                    scoring.setAction(ScoringAction.AMP_AIM);
+                    break;
+                case SOURCE:
+                    scoring.setAction(ScoringAction.SOURCE_INTAKE);
+                    break;
+                case ENDGAME:
+                    scoring.setAction(ScoringAction.ENDGAME);
+                    break;
+            }
+
+            /*
+             * If the scorer is commanded to shoot from a non-shootable state, it will start trying to
+             * shoot at the speaker. We want the shoot button to do nothing in an un-shootable state.
+             */
+            if ((driverShoot.getAsBoolean() || masherShoot.getAsBoolean())
+                    && getDriveMode.get() != AlignTarget.SOURCE
+                    && getDriveMode.get() != AlignTarget.NONE) {
+                scoring.setAction(ScoringAction.SHOOT);
+            }
+        } else if (reverseIntake.getAsBoolean()) {
+            scoring.setAction(ScoringAction.SPIT);
+        } else {
+            scoring.setAction(ScoringAction.WAIT);
+        }
+    }
+}

--- a/src/main/java/frc/robot/commands/ShootWithGamepad.java
+++ b/src/main/java/frc/robot/commands/ShootWithGamepad.java
@@ -10,7 +10,9 @@ import java.util.function.Supplier;
 public class ShootWithGamepad extends Command {
 
     private BooleanSupplier driverShoot;
+    private BooleanSupplier driverForceShoot;
     private BooleanSupplier masherShoot;
+    private BooleanSupplier masherForceShoot;
     private BooleanSupplier warmup;
     private BooleanSupplier reverseIntake;
     private BooleanSupplier intake;
@@ -21,14 +23,18 @@ public class ShootWithGamepad extends Command {
 
     public ShootWithGamepad(
             BooleanSupplier driverShoot,
+            BooleanSupplier driverForceShoot,
             BooleanSupplier masherShoot,
+            BooleanSupplier masherForceShoot,
             BooleanSupplier warmup,
             BooleanSupplier reverseIntake,
             BooleanSupplier intake,
             ScoringSubsystem scoring,
             Supplier<AlignTarget> getDriveMode) {
         this.driverShoot = driverShoot;
+        this.driverForceShoot = driverForceShoot;
         this.masherShoot = masherShoot;
+        this.masherForceShoot = masherForceShoot;
         this.warmup = warmup;
         this.reverseIntake = reverseIntake;
         this.intake = intake;
@@ -67,10 +73,14 @@ public class ShootWithGamepad extends Command {
              * If the scorer is commanded to shoot from a non-shootable state, it will start trying to
              * shoot at the speaker. We want the shoot button to do nothing in an un-shootable state.
              */
-            if ((driverShoot.getAsBoolean() || masherShoot.getAsBoolean())
-                    && getDriveMode.get() != AlignTarget.SOURCE
+            if (getDriveMode.get() != AlignTarget.SOURCE
                     && getDriveMode.get() != AlignTarget.NONE) {
-                scoring.setAction(ScoringAction.SHOOT);
+                boolean force = driverForceShoot.getAsBoolean() || masherForceShoot.getAsBoolean();
+                scoring.setOverrideShoot(force);
+
+                if (driverShoot.getAsBoolean() || masherShoot.getAsBoolean() || force) {
+                    scoring.setAction(ScoringAction.SHOOT);
+                }
             }
         } else if (reverseIntake.getAsBoolean()) {
             scoring.setAction(ScoringAction.SPIT);

--- a/src/main/java/frc/robot/commands/ShootWithGamepad.java
+++ b/src/main/java/frc/robot/commands/ShootWithGamepad.java
@@ -13,6 +13,7 @@ public class ShootWithGamepad extends Command {
     private BooleanSupplier masherShoot;
     private BooleanSupplier warmup;
     private BooleanSupplier reverseIntake;
+    private BooleanSupplier intake;
 
     private ScoringSubsystem scoring;
 
@@ -23,12 +24,14 @@ public class ShootWithGamepad extends Command {
             BooleanSupplier masherShoot,
             BooleanSupplier warmup,
             BooleanSupplier reverseIntake,
+            BooleanSupplier intake,
             ScoringSubsystem scoring,
             Supplier<AlignTarget> getDriveMode) {
         this.driverShoot = driverShoot;
         this.masherShoot = masherShoot;
         this.warmup = warmup;
         this.reverseIntake = reverseIntake;
+        this.intake = intake;
 
         this.scoring = scoring;
         this.getDriveMode = getDriveMode;
@@ -71,6 +74,8 @@ public class ShootWithGamepad extends Command {
             }
         } else if (reverseIntake.getAsBoolean()) {
             scoring.setAction(ScoringAction.SPIT);
+        } else if (intake.getAsBoolean()) {
+            scoring.setAction(ScoringAction.INTAKE);
         } else {
             scoring.setAction(ScoringAction.WAIT);
         }

--- a/src/main/java/frc/robot/subsystems/drive/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drive/CommandSwerveDrivetrain.java
@@ -50,7 +50,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
         NONE,
         AMP,
         SPEAKER,
-        SOURCE
+        SOURCE,
+        ENDGAME
     }
 
     public enum AlignState {
@@ -154,6 +155,10 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
 
     public AlignState getAlignState() {
         return alignState;
+    }
+
+    public AlignTarget getAlignTarget() {
+        return alignTarget;
     }
 
     public void setVelocitySupplier(Supplier<Translation2d> getRobotVelocity) {
@@ -270,7 +275,7 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
                     break;
                 case NONE:
                     break;
-                default:
+                case ENDGAME:
                     break;
             }
 

--- a/src/main/java/frc/robot/subsystems/endgame/EndgameIOSparkFlex.java
+++ b/src/main/java/frc/robot/subsystems/endgame/EndgameIOSparkFlex.java
@@ -33,6 +33,7 @@ public class EndgameIOSparkFlex implements EndgameIO {
     public void setBrakeMode(boolean brake) {
         IdleMode sparkMode = brake ? IdleMode.kBrake : IdleMode.kCoast;
         leftEndgameMotor.setIdleMode(sparkMode);
+        rightEndgameMotor.setIdleMode(sparkMode);
     }
 
     @Override


### PR DESCRIPTION
I've updated the [bindings spreadsheet](https://docs.google.com/spreadsheets/d/1g4tnNMrozS9zXPHDpUvcfFnnWgqiTqcrnx35lZKeaEE/edit#gid=580036986) to match current robot behavior (and broadly make more sense). This PR updates RobotContainer to implement those bindings.

In future I would support adding a screenshot of the control diagram to our readme.