### PR TITLE
add uptake banner sensor

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -72,6 +72,7 @@ public final class Constants {
 
     public static final class SensorConstants {
         public static final int bannerSensorPort = 1;
+        public static final int uptakeSensorPort = 2;
     }
 
     public static final class DriveConstants {

--- a/src/main/java/frc/robot/subsystems/intake/IntakeIOSparkMax.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeIOSparkMax.java
@@ -8,7 +8,9 @@ import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 import com.revrobotics.CANSparkMax;
+import edu.wpi.first.wpilibj.DigitalInput;
 import frc.robot.Constants.IntakeConstants;
+import frc.robot.Constants.SensorConstants;
 
 public class IntakeIOSparkMax implements IntakeIO {
 
@@ -18,6 +20,8 @@ public class IntakeIOSparkMax implements IntakeIO {
             new CANSparkMax(IntakeConstants.rightIntakeMotorID, MotorType.kBrushless);
 
     private TalonFX belt = new TalonFX(IntakeConstants.indexTwoMotorID);
+
+    private DigitalInput uptakeSensor = new DigitalInput(SensorConstants.uptakeSensorPort);
 
     public IntakeIOSparkMax() {
         leftIntake.setSmartCurrentLimit(40, 40);
@@ -47,6 +51,8 @@ public class IntakeIOSparkMax implements IntakeIO {
         inputs.beltVoltage = belt.getMotorVoltage().getValueAsDouble();
         inputs.beltStatorCurrent = belt.getStatorCurrent().getValueAsDouble();
         inputs.beltSupplyCurrent = belt.getSupplyCurrent().getValueAsDouble();
+
+        inputs.noteSensed = !uptakeSensor.get();
     }
 
     @Override

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -78,7 +78,7 @@ public class IntakeSubsystem extends SubsystemBase {
                                 .getAsBoolean())) { // dont seek if note in uptake or shotoer deck
             state = State.SEEKING;
         } else if (action == IntakeAction.REVERSE
-                || inputs.noteSensed) { // reverse if note is found
+                || (inputs.noteSensed && noteInShooterDeck.getAsBoolean())) { // reverse if note is found
             state = State.REVERSING;
         } else if (action == IntakeAction.OVERRIDE) {
             state = State.OVERRIDE;
@@ -92,8 +92,11 @@ public class IntakeSubsystem extends SubsystemBase {
         if (action != IntakeAction.INTAKE) {
             state = State.IDLE;
         }
-
-        io.setIntakeVoltage(IntakeConstants.intakePower);
+        if(!inputs.noteSensed) { // run until note is in uptake
+            io.setIntakeVoltage(IntakeConstants.intakePower);
+        } else {
+            io.setIntakeVoltage(0);
+        }
         io.setBeltVoltage(IntakeConstants.beltPower);
     }
 

--- a/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/intake/IntakeSubsystem.java
@@ -78,7 +78,8 @@ public class IntakeSubsystem extends SubsystemBase {
                                 .getAsBoolean())) { // dont seek if note in uptake or shotoer deck
             state = State.SEEKING;
         } else if (action == IntakeAction.REVERSE
-                || (inputs.noteSensed && noteInShooterDeck.getAsBoolean())) { // reverse if note is found
+                || (inputs.noteSensed
+                        && noteInShooterDeck.getAsBoolean())) { // reverse if note is found
             state = State.REVERSING;
         } else if (action == IntakeAction.OVERRIDE) {
             state = State.OVERRIDE;
@@ -92,7 +93,7 @@ public class IntakeSubsystem extends SubsystemBase {
         if (action != IntakeAction.INTAKE) {
             state = State.IDLE;
         }
-        if(!inputs.noteSensed) { // run until note is in uptake
+        if (!inputs.noteSensed) { // run until note is in uptake
             io.setIntakeVoltage(IntakeConstants.intakePower);
         } else {
             io.setIntakeVoltage(0);


### PR DESCRIPTION
**Summary**: add sensor to uptake to prevent intake from running with note already in. This will prevent tech fouls.

**Changes**:

- add banner sensor to intake io (easily change to break sensor)
- add boolean supplier for intake to check if note in shooter deck
- add check in idle mode (don't set intake action if note is sensed in uptake)
- add check in reversing state for note in shooter deck (if so run belt backwards)
Resolves  #149