### PR TITLE
Adds stateful command for Automated Teleop

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -118,6 +118,11 @@ public final class Constants {
         // TODO: Find constants for automated teleop command
         public static final double intakeTimeoutSeconds = 0.5;
         public static final double retryIntakeWaitSeconds = 0.5;
+
+        public static final double shootRangeMeters = 3.0;
+
+        // The distance from the source at which to stop driving the robot
+        public static final double sourceRangeMeters = 1.5;
     }
 
     public static final class FieldConstants {
@@ -179,6 +184,16 @@ public final class Constants {
 
         public static final Pose2d robotAgainstRedAmpZone =
                 new Pose2d(13.74, 7.68, Rotation2d.fromDegrees(-90));
+
+        public static final Pose2d robotAgainstBlueSource =
+                new Pose2d(14.82, 0.69, Rotation2d.fromDegrees(-60));
+
+        public static final Pose2d robotAgainstRedSource =
+                new Pose2d(1.63, 0.69, Rotation2d.fromDegrees(60));
+
+        // TODO: Find actual coordinates of shop source
+        public static final Pose2d robotAgainstShopSource =
+                new Pose2d(8.30, 6.80, Rotation2d.fromDegrees(60));
     }
 
     public static final class VisionConstants {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -114,6 +114,12 @@ public final class Constants {
         public static final double vYkD = 0.0;
     }
 
+    public static final class AutomatedTeleopConstants {
+        // TODO: Find constants for automated teleop command
+        public static final double intakeTimeoutSeconds = 0.5;
+        public static final double retryIntakeWaitSeconds = 0.5;
+    }
+
     public static final class FieldConstants {
         public static final double lengthM = 16.451;
         public static final double widthM = 8.211;

--- a/src/main/java/frc/robot/commands/AutomatedTeleop.java
+++ b/src/main/java/frc/robot/commands/AutomatedTeleop.java
@@ -1,0 +1,113 @@
+package frc.robot.commands;
+
+import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.Constants.AutomatedTeleopConstants;
+import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
+import frc.robot.subsystems.intake.IntakeSubsystem;
+import frc.robot.subsystems.intake.IntakeSubsystem.IntakeAction;
+import frc.robot.subsystems.scoring.ScoringSubsystem;
+import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringAction;
+import frc.robot.telemetry.Telemetry;
+
+public class AutomatedTeleop extends Command {
+    ScoringSubsystem scoringSubsystem;
+    IntakeSubsystem intakeSubsystem;
+    CommandSwerveDrivetrain drivetrain;
+
+    Telemetry telemetry;
+
+    private Timer timer;
+
+    private enum State {
+        START,
+        DRIVE_TO_SOURCE,
+        INTAKE_NOTE,
+        RETRY_INTAKE,
+        DRIVE_TO_SCORING,
+    }
+
+    private State state;
+
+    public AutomatedTeleop(
+            ScoringSubsystem scoringSubsystem,
+            IntakeSubsystem intakeSubsystem,
+            CommandSwerveDrivetrain drivetrain,
+            Telemetry telemetry) {
+        this.scoringSubsystem = scoringSubsystem;
+        this.intakeSubsystem = intakeSubsystem;
+        this.drivetrain = drivetrain;
+        this.telemetry = telemetry;
+
+        timer = new Timer();
+
+        addRequirements(scoringSubsystem, intakeSubsystem, drivetrain);
+    }
+
+    @Override
+    public void initialize() {
+        this.state = State.START;
+
+        scoringSubsystem.setAction(ScoringAction.WAIT);
+        scoringSubsystem.forceHood(false);
+    }
+
+    @Override
+    public void execute() {
+        switch (state) {
+            case START:
+                if (intakeSubsystem.hasNote()) {
+                    state = State.DRIVE_TO_SCORING;
+                } else {
+                    state = State.DRIVE_TO_SOURCE;
+                }
+                break;
+            case DRIVE_TO_SOURCE:
+                // TODO: Implement automation of driving
+
+                scoringSubsystem.setAction(ScoringAction.WAIT);
+                if (false /*<-- are we at the source */) { // TODO: Check if we're close enough to
+                    // the source to intake
+                    state = State.INTAKE_NOTE;
+                    timer.restart();
+                }
+                break;
+            case INTAKE_NOTE:
+                // TODO: Fully implement automation of intake
+
+                intakeSubsystem.run(IntakeAction.INTAKE);
+
+                if (intakeSubsystem.hasNote()) {
+                    state = State.DRIVE_TO_SCORING;
+                } else if (timer.get() > AutomatedTeleopConstants.intakeTimeoutSeconds) {
+                    state = State.RETRY_INTAKE;
+                    timer.restart();
+                }
+                break;
+            case RETRY_INTAKE:
+                // TODO: Implement automation of intake
+
+                // Drive away from the source and wait for a certain timer
+
+                // Once we are away and the time has elapsed, drive back
+                if (timer.get()
+                        > AutomatedTeleopConstants
+                                .retryIntakeWaitSeconds /* && we are at target destination */) {
+                    // Now that we've backed off, drive back and try to intake again
+                    state = State.DRIVE_TO_SOURCE;
+                }
+                break;
+            case DRIVE_TO_SCORING:
+                // If we don't have a note, go get one
+                // This will work for if we drop our note or for after we've shot
+                if (!intakeSubsystem.hasNote()) {
+                    // TODO: Use note vision to pick up a nearby note rather than going to source?
+                    state = State.DRIVE_TO_SOURCE;
+                }
+                // TODO: Implement automation of driving
+
+                scoringSubsystem.setAction(ScoringAction.SHOOT);
+                break;
+        }
+    }
+}

--- a/src/main/java/frc/robot/commands/AutomatedTeleop.java
+++ b/src/main/java/frc/robot/commands/AutomatedTeleop.java
@@ -1,30 +1,32 @@
 package frc.robot.commands;
 
-import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants.AutomatedTeleopConstants;
+import frc.robot.Constants.FieldConstants;
 import frc.robot.subsystems.drive.CommandSwerveDrivetrain;
 import frc.robot.subsystems.intake.IntakeSubsystem;
 import frc.robot.subsystems.intake.IntakeSubsystem.IntakeAction;
 import frc.robot.subsystems.scoring.ScoringSubsystem;
 import frc.robot.subsystems.scoring.ScoringSubsystem.ScoringAction;
 import frc.robot.telemetry.Telemetry;
+import java.util.function.Supplier;
 
 public class AutomatedTeleop extends Command {
     ScoringSubsystem scoringSubsystem;
     IntakeSubsystem intakeSubsystem;
     CommandSwerveDrivetrain drivetrain;
 
-    Telemetry telemetry;
+    private Supplier<Pose2d> poseSupplier = () -> new Pose2d();
 
-    private Timer timer;
+    Telemetry telemetry;
 
     private enum State {
         START,
         DRIVE_TO_SOURCE,
-        INTAKE_NOTE,
-        RETRY_INTAKE,
-        DRIVE_TO_SCORING,
+        ACQUIRE_NOTE,
+        DRIVE_TO_SPEAKER,
+        SHOOT_NOTE,
     }
 
     private State state;
@@ -33,13 +35,14 @@ public class AutomatedTeleop extends Command {
             ScoringSubsystem scoringSubsystem,
             IntakeSubsystem intakeSubsystem,
             CommandSwerveDrivetrain drivetrain,
-            Telemetry telemetry) {
+            Telemetry telemetry,
+            Supplier<Pose2d> poseSupplier) {
         this.scoringSubsystem = scoringSubsystem;
         this.intakeSubsystem = intakeSubsystem;
         this.drivetrain = drivetrain;
         this.telemetry = telemetry;
 
-        timer = new Timer();
+        this.poseSupplier = poseSupplier;
 
         addRequirements(scoringSubsystem, intakeSubsystem, drivetrain);
     }
@@ -52,61 +55,78 @@ public class AutomatedTeleop extends Command {
         scoringSubsystem.forceHood(false);
     }
 
+    private double findDistanceToSource() {
+        // NOTE: Leave one of the following lines commented out depending on the scenario:
+
+        // Uncomment this line for actual production code:
+        // Pose2d sourcePose = AllianceUtil.getPoseAgainstSource();
+
+        // Uncomment this line for testing with shop source
+        Pose2d sourcePose = FieldConstants.robotAgainstShopSource;
+
+        Pose2d robotPose = poseSupplier.get();
+        double distancetoGoal =
+                Math.sqrt(
+                        Math.pow(Math.abs(robotPose.getX() - sourcePose.getX()), 2)
+                                + Math.pow(Math.abs(robotPose.getY() - sourcePose.getY()), 2));
+        return distancetoGoal;
+    }
+
     @Override
     public void execute() {
         switch (state) {
             case START:
                 if (intakeSubsystem.hasNote()) {
-                    state = State.DRIVE_TO_SCORING;
+                    state = State.DRIVE_TO_SPEAKER;
                 } else {
                     state = State.DRIVE_TO_SOURCE;
                 }
                 break;
             case DRIVE_TO_SOURCE:
-                // TODO: Implement automation of driving
+                drivetrain.driveToSource();
 
                 scoringSubsystem.setAction(ScoringAction.WAIT);
-                if (false /*<-- are we at the source */) { // TODO: Check if we're close enough to
-                    // the source to intake
-                    state = State.INTAKE_NOTE;
-                    timer.restart();
+                // Once robot reaches the source, stop driving and try to acquire a note
+                if (findDistanceToSource()
+                        < AutomatedTeleopConstants.sourceRangeMeters /* || note detected */) {
+                    state = State.ACQUIRE_NOTE;
                 }
                 break;
-            case INTAKE_NOTE:
+            case ACQUIRE_NOTE:
                 // TODO: Fully implement automation of intake
 
+                drivetrain.stopDriveToPose();
                 intakeSubsystem.run(IntakeAction.INTAKE);
 
                 if (intakeSubsystem.hasNote()) {
-                    state = State.DRIVE_TO_SCORING;
-                } else if (timer.get() > AutomatedTeleopConstants.intakeTimeoutSeconds) {
-                    state = State.RETRY_INTAKE;
-                    timer.restart();
+                    state = State.DRIVE_TO_SPEAKER;
                 }
                 break;
-            case RETRY_INTAKE:
-                // TODO: Implement automation of intake
-
-                // Drive away from the source and wait for a certain timer
-
-                // Once we are away and the time has elapsed, drive back
-                if (timer.get()
-                        > AutomatedTeleopConstants
-                                .retryIntakeWaitSeconds /* && we are at target destination */) {
-                    // Now that we've backed off, drive back and try to intake again
-                    state = State.DRIVE_TO_SOURCE;
-                }
-                break;
-            case DRIVE_TO_SCORING:
+            case DRIVE_TO_SPEAKER:
                 // If we don't have a note, go get one
                 // This will work for if we drop our note or for after we've shot
                 if (!intakeSubsystem.hasNote()) {
                     // TODO: Use note vision to pick up a nearby note rather than going to source?
                     state = State.DRIVE_TO_SOURCE;
                 }
-                // TODO: Implement automation of driving
 
+                drivetrain.driveToSpeaker();
+                scoringSubsystem.setAction(ScoringAction.AIM);
+
+                // Once we are in range, shoot
+                if (scoringSubsystem.findDistanceToGoal()
+                        < AutomatedTeleopConstants.shootRangeMeters) {
+                    state = State.SHOOT_NOTE;
+                }
+                break;
+            case SHOOT_NOTE:
+                if (!intakeSubsystem.hasNote()) {
+                    state = State.DRIVE_TO_SOURCE;
+                }
+
+                drivetrain.driveToSpeaker();
                 scoringSubsystem.setAction(ScoringAction.SHOOT);
+
                 break;
         }
     }

--- a/src/main/java/frc/robot/subsystems/drive/CommandSwerveDrivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drive/CommandSwerveDrivetrain.java
@@ -120,6 +120,7 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
     private Notifier simNotifier = null;
     private double lastSimTime;
 
+    private String lastCommandedPath = "";
     private Command pathfindCommand = null;
 
     private Pose2d pathfindPose = new Pose2d();
@@ -552,6 +553,11 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
     }
 
     public void driveToPath(String pathName) {
+        if (pathName == lastCommandedPath) {
+            return;
+        } else {
+            lastCommandedPath = pathName;
+        }
         this.setAlignState(AlignState.MANUAL);
 
         PathPlannerPath path = PathPlannerPath.fromPathFile(pathName);
@@ -580,6 +586,8 @@ public class CommandSwerveDrivetrain extends SwerveDrivetrain implements Subsyst
         if (pathfindCommand != null) {
             pathfindCommand.cancel();
         }
+
+        lastCommandedPath = "";
 
         setGoalChassisSpeeds(stopSpeeds, true);
     }

--- a/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/scoring/ScoringSubsystem.java
@@ -407,7 +407,7 @@ public class ScoringSubsystem extends SubsystemBase implements Tunable {
         }
     }
 
-    private double findDistanceToGoal() {
+    public double findDistanceToGoal() {
         Translation2d speakerPose = AllianceUtil.getFieldToSpeaker();
         Pose2d robotPose = poseSupplier.get();
         double distancetoGoal =

--- a/src/main/java/frc/robot/utils/AllianceUtil.java
+++ b/src/main/java/frc/robot/utils/AllianceUtil.java
@@ -88,6 +88,18 @@ public class AllianceUtil {
         return FieldConstants.robotAgainstRedAmpZone;
     }
 
+    public static Pose2d getPoseAgainstSource() {
+        if (!DriverStation.getAlliance().isEmpty()) {
+            switch (DriverStation.getAlliance().get()) {
+                case Blue:
+                    return FieldConstants.robotAgainstRedSource;
+                case Red:
+                    return FieldConstants.robotAgainstBlueSource;
+            }
+        }
+        return FieldConstants.robotAgainstRedSource;
+    }
+
     public static Rotation2d getSourceHeading() {
         if (!DriverStation.getAlliance().isEmpty()) {
             switch (DriverStation.getAlliance().get()) {


### PR DESCRIPTION
**Purpose**
This PR adds a new command to control teleop autonomously.
Closes #182.

**Features**
A state machine with the following states:
- `START`
  - Initial state when the command is initialized.
  - If the robot has a note, switch to `DRIVE_TO_SPEAKER`.
  - If the robot doesn't have a note, switch to `DRIVE_TO_SOURCE`.
- `DRIVE_TO_SOURCE`
  - Once a note is detected with vision (not yet implemented) or the robot reaches the source, switch to `ACQUIRE_NOTE` to go intake the note.
- `ACQUIRE_NOTE`
  - Currently just sits still and spins the intake, waiting for a note to be pushed into the robot
  - Once the robot has a note, switch to `DRIVE_TO_SPEAKER`
- `DRIVE_TO_SPEAKER`
  - This state will prime the speaker and then detect if the robot is in a location that it can safely shoot from and switch to `SHOOT_NOTE`. This currently only checks range to the speaker in deciding whether or not to switch to the score note state.
- `SHOOT_NOTE`
  - Continue driving toward the speaker while commanding the scoring subsystem to shoot when ready.
  - Once the note has been shot, return to `DRIVE_TO_SOURCE`.

The state machine can be seen in the diagram below:
![image](https://github.com/team401/2024-Robot-Code/assets/99768676/b6f85a03-d3ea-419f-8612-863e788a85b1)

**Outstanding Work**
- Add note vision to `DRIVE_TO_SOURCE` to detect when a note is near and switch to `ACQUIRE_NOTE`.
- Revamp `ACQUIRE_NOTE` to use note vision and/or retry logic to be able to actually intake notes by itself.
- Finalize PathPlanner paths to sources (especially shop source)
  - Consider adding a better way to switch between shop and competition environments (currently decided by just commenting/uncommenting various lines throughout the project). This might be better as a separate issue (maybe in conjunction with the JSON configs issue), and it can probably wait until then.
- Mermaid diagram for the state machine
  - I am currently working on an update to Secretary (the Mermaid generator script) to improve the handling of states that only have one check (for instance, `START` only checks `hasNote()` and then will transition to one state or another depending on whether it is true or false). After this feature is done, I'll add a Mermaid diagram for the command.