### PR TITLE
Add fault detection and auto-shutoff to shooter if encoder is unplugged

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -53,7 +53,7 @@ public final class Constants {
         public static final boolean runLocalizer = true;
 
         public static final boolean runIntake = false;
-        public static final boolean runScoring = false;
+        public static final boolean runScoring = true;
         public static final boolean runEndgame = false;
         public static final boolean runDrive = true;
 
@@ -479,6 +479,9 @@ public final class Constants {
         public static final double aimerkP = 17.0;
         public static final double aimerkI = 10.0; // 5.0
         public static final double aimerkD = 0.0;
+
+        public static final double aimerMovementThresholdRadPerSec = 0.05;
+        public static final double maxAimUnresponsiveTimeSeconds = 0.1;
 
         public static final double aimerkS = 0.265;
         public static final double aimerkG = 0.1;

--- a/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
+++ b/src/main/java/frc/robot/subsystems/scoring/AimerIORoboRio.java
@@ -213,7 +213,7 @@ public class AimerIORoboRio implements AimerIO {
                     feedforward.calculate(controlSetpoint, velocitySetpoint) + controllerVolts;
         }
 
-        appliedVolts = MathUtil.clamp(appliedVolts, -12.0, 12.0);
+        appliedVolts = MathUtil.clamp(appliedVolts, -4.0, 4.0);
         if (!motorDisabled || override) {
             aimerRight.setVoltage(appliedVolts);
         } else {

--- a/src/main/java/frc/robot/subsystems/scoring/AimerIOSim.java
+++ b/src/main/java/frc/robot/subsystems/scoring/AimerIOSim.java
@@ -126,6 +126,8 @@ public class AimerIOSim implements AimerIO {
             sim.setInputVoltage(appliedVolts);
         }
 
+        sim.setInputVoltage(0.0);
+
         inputs.aimGoalAngleRad = goalAngleRad;
         inputs.aimProfileGoalAngleRad = trapezoidSetpoint.position;
         inputs.aimAngleRad = sim.getAngleRads();


### PR DESCRIPTION
**Purpose**
The purpose of this PR is to disable the shooter arm if the encoder is detected to have failed.

Detection criteria:
If the arm is commanded to move at above 2x the kS, and the measured velocity is less than some value for some persistence, switch to manual arm control. At this point, the arm is just set to a permanent override of 0 volts until the code is restarted when a fault is detected, and the fault state is logged under `scoring/fault`.

**Project Scope**
- [ ] Add auto cutoff for shooter arm per above specification 
- [ ] Fine tune movement threshold and amount of time before shutoff to detect faults when necessary but also to avoid false positives.